### PR TITLE
fix for #1

### DIFF
--- a/CUDA_Kernels.cu
+++ b/CUDA_Kernels.cu
@@ -42,7 +42,6 @@
 //                              Definitions                                   //
 //----------------------------------------------------------------------------//
 
-__constant__  TEvolutionParameters GPU_EvolutionParameters;
 
 
 

--- a/GPU_Population.cu
+++ b/GPU_Population.cu
@@ -29,7 +29,7 @@
 
 #include <stdio.h>
 #include <stdexcept>
-#include <cutil_inline.h>
+#include <helper_cuda.h>
 #include <sstream>
 
 #include "GPU_Population.h"
@@ -98,7 +98,7 @@ void TGPU_Population::CopyIn(const TPopulationData * HostSource){
     }
     
     // Copy chromosomes 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FHost_Handlers.Population,
                     HostSource->Population, sizeof(TGene) * FHost_Handlers.ChromosomeSize * FHost_Handlers.PopulationSize, 
                     cudaMemcpyHostToDevice)
@@ -106,7 +106,7 @@ void TGPU_Population::CopyIn(const TPopulationData * HostSource){
     
     
     // Copy fitness values
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FHost_Handlers.Fitness, 
                     HostSource->Fitness, sizeof(TFitness) * FHost_Handlers.PopulationSize, 
                     cudaMemcpyHostToDevice)
@@ -135,7 +135,7 @@ void TGPU_Population::CopyOut (TPopulationData * HostDestination){
     }
     
     // Copy chromosomes --//
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(HostDestination->Population, FHost_Handlers.Population, 
                     sizeof(TGene) * FHost_Handlers.ChromosomeSize * FHost_Handlers.PopulationSize, 
                     cudaMemcpyDeviceToHost)
@@ -143,7 +143,7 @@ void TGPU_Population::CopyOut (TPopulationData * HostDestination){
     
     
     //-- Copy fitnesses --//
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(HostDestination->Fitness, 
                     FHost_Handlers.Fitness, sizeof(TFitness) * FHost_Handlers.PopulationSize, 
                     cudaMemcpyDeviceToHost)
@@ -164,7 +164,7 @@ void TGPU_Population::CopyOut (TPopulationData * HostDestination){
  */
 void TGPU_Population::CopyOutIndividual(TGene * Individual, int Index){
     
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(Individual, &(FHost_Handlers.Population[Index * FHost_Handlers.ChromosomeSize]), 
                     sizeof(TGene) * FHost_Handlers.ChromosomeSize, cudaMemcpyDeviceToHost)
          );    
@@ -193,14 +193,14 @@ void TGPU_Population::CopyDeviceIn(const TGPU_Population * GPUPopulation){
     }
     
     // Copy chromosomes 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FHost_Handlers.Population, GPUPopulation->FHost_Handlers.Population, sizeof(TGene) * FHost_Handlers.ChromosomeSize * FHost_Handlers.PopulationSize, 
                     cudaMemcpyDeviceToDevice)
          );    
     
     
     // Copy fintess values
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FHost_Handlers.Fitness, GPUPopulation->FHost_Handlers.Fitness, sizeof(TFitness) * FHost_Handlers.PopulationSize, 
                     cudaMemcpyDeviceToDevice)
          );    
@@ -222,24 +222,24 @@ void TGPU_Population::AllocateCudaMemory(){
     
     
     // Allocate data structure
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&DeviceData,  sizeof(TPopulationData))
            );		
     
     
     // Allocate Population data
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&(FHost_Handlers.Population),  sizeof(TGene) * FHost_Handlers.ChromosomeSize * FHost_Handlers.PopulationSize)
            );		
     
     // Allocate Fitness data
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&(FHost_Handlers.Fitness),  sizeof(TFitness) * FHost_Handlers.PopulationSize)
            );		
     
     
     // Copy structure to GPU 
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMemcpy(DeviceData, &FHost_Handlers, sizeof(TPopulationData),cudaMemcpyHostToDevice )
            );		
     
@@ -254,18 +254,18 @@ void TGPU_Population::FreeCudaMemory(){
        
     
     // Free population data
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(FHost_Handlers.Population)
            );  
      
     //Free Fitness data
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(FHost_Handlers.Fitness) 
            );  
      
     
     // Free whole structure 
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(DeviceData)
            );  
     
@@ -353,12 +353,12 @@ string TCPU_Population::GetStringOfChromosome(const int Idx){
 void TCPU_Population::AllocateCudaMemory(){
     
     // Allocate Population on the host side
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaHostAlloc((void**)&HostData->Population,  sizeof(TGene) * HostData->ChromosomeSize * HostData->PopulationSize,cudaHostAllocDefault )
             );		
 
     // Allocate fitness on the host side
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaHostAlloc((void**)&HostData->Fitness,  sizeof(TFitness) *  HostData->PopulationSize,cudaHostAllocDefault )
             );		
     
@@ -372,12 +372,12 @@ void TCPU_Population::AllocateCudaMemory(){
 void TCPU_Population::FreeCudaMemory(){
     
     // Free population on the host side
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaFreeHost(HostData->Population)
             );
     
     // Free fitness on the host side
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaFreeHost(HostData->Fitness)
             );            
     

--- a/GPU_Statistics.cu
+++ b/GPU_Statistics.cu
@@ -26,7 +26,7 @@
  * Created on 24 March 2012, 00:00 PM
  */
 
-#include <cutil_inline.h>
+#include <helper_cuda.h>
 #include <sstream>
 
 #include "GPU_Statistics.h"
@@ -154,13 +154,13 @@ void TGPU_Statistics::AllocateCudaMemory(){
     //------------ Host data ---------------//
     
     // Allocate basic Host structure 
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaHostAlloc((void**)&HostData,  sizeof(TStatisticsData)
                            ,cudaHostAllocDefault )
             );		
     
     // Allocate best individual on the host side
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaHostAlloc((void**)&HostBestIndividual,  sizeof(TGene) * TParameters::GetInstance()->ChromosomeSize()                        
                            ,cudaHostAllocDefault)
             );		
@@ -169,7 +169,7 @@ void TGPU_Statistics::AllocateCudaMemory(){
     //------------ Device data ---------------//
         
     // Allocate data structure on host side
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&DeviceData,  sizeof(TStatisticsData))
            );		
        
@@ -185,18 +185,18 @@ void TGPU_Statistics::FreeCudaMemory(){
        
     
     // Free CPU Best individual 
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaFreeHost(HostBestIndividual)
             );
     
     // Free structure in host memory
-    cutilSafeCall( 
+    checkCudaErrors(
             cudaFreeHost(HostData)
             );
             
     
     // Free whole structure
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(DeviceData)
            );  
     
@@ -219,7 +219,7 @@ void TGPU_Statistics::CopyOut(TGPU_Population * Population, bool PrintBest){
     TParameters * Params = TParameters::GetInstance(); 
     
     // Copy 4 statistics values 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(HostData, DeviceData, sizeof(TStatisticsData), 
                     cudaMemcpyDeviceToHost)
          );    
@@ -251,7 +251,7 @@ void TGPU_Statistics::InitStatistics(){
             
     
     // Copy 4 statistics values 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(DeviceData, HostData, sizeof(TStatisticsData), 
                     cudaMemcpyHostToDevice)
          );    

--- a/GlobalKnapsackData.cu
+++ b/GlobalKnapsackData.cu
@@ -26,7 +26,7 @@
  * Created on 30 March 2012, 00:00 PM
  */
 
-#include <cutil_inline.h>
+#include <helper_cuda.h>
 #include <fstream>
 #include <iostream>
 
@@ -167,15 +167,15 @@ void TGlobalKnapsackData::AllocateMemory(int NumberOfItems){
     
     //------------------------- Host allocation ------------------------------//    
     //------------------- All data allocated by PINNED memory ----------------//
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaHostAlloc((void**)&HostData,  sizeof(TKnapsackData), cudaHostAllocDefault)
            );		
     
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaHostAlloc((void**)&HostData->ItemPrice,  sizeof(TPriceType) * NumberOfItems, cudaHostAllocDefault)
            );		
     
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaHostAlloc((void**)&HostData->ItemWeight,  sizeof(TWeightType)* NumberOfItems, cudaHostAllocDefault)
            );		
     
@@ -183,15 +183,15 @@ void TGlobalKnapsackData::AllocateMemory(int NumberOfItems){
     
     
     //----------------------- Device allocation ------------------------------//    
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&(DeviceData),  sizeof(TKnapsackData) )
            );		
             
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&(FDeviceItemPriceHandler),  sizeof(TPriceType) * NumberOfItems)
            );		
         
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaMalloc((void**)&(FDeviceItemWeightHandler),  sizeof(TWeightType) * NumberOfItems)
            );		
             
@@ -206,15 +206,15 @@ void TGlobalKnapsackData::AllocateMemory(int NumberOfItems){
 void TGlobalKnapsackData::FreeMemory(){
     
     //------------------------- Host allocation ------------------------------//        
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFreeHost(HostData->ItemPrice)
            );		
     
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFreeHost(HostData->ItemWeight)            
            );		
     
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFreeHost(HostData)
            );		
     
@@ -222,14 +222,14 @@ void TGlobalKnapsackData::FreeMemory(){
     
     
     //----------------------- Device allocation ------------------------------//    
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(DeviceData)
            );		
         
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(FDeviceItemPriceHandler)
            );		        
-    cutilSafeCall( 
+    checkCudaErrors(
            cudaFree(FDeviceItemWeightHandler)
            );		        
     
@@ -245,21 +245,21 @@ void TGlobalKnapsackData::UploadDataToDevice(){
     
     
     // Copy basic structure - struct data
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(DeviceData, HostData, sizeof(TKnapsackData), 
                     cudaMemcpyHostToDevice)
          );    
         
     
     // Set pointer of the ItemPrice vector into the struct on GPU (link struct and vector)
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(&(DeviceData->ItemPrice), &FDeviceItemPriceHandler, sizeof(TPriceType * ), 
                     cudaMemcpyHostToDevice)
          );    
     
 
     // Set pointer of the ItemWeight vector into struct on GPU (link struct and vector)
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(&(DeviceData->ItemWeight), &FDeviceItemWeightHandler, sizeof(TWeightType * ), 
                     cudaMemcpyHostToDevice)
          );    
@@ -267,13 +267,13 @@ void TGlobalKnapsackData::UploadDataToDevice(){
     
         
     // Copy prices 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FDeviceItemPriceHandler, HostData->ItemPrice,  sizeof(TPriceType) * HostData->NumberOfItems, 
                     cudaMemcpyHostToDevice)
          );    
     
     // Copy weights 
-    cutilSafeCall( 
+    checkCudaErrors(
          cudaMemcpy(FDeviceItemWeightHandler, HostData->ItemWeight, sizeof(TWeightType) * HostData->NumberOfItems, 
                     cudaMemcpyHostToDevice)
          );    

--- a/Parameters.cu
+++ b/Parameters.cu
@@ -29,9 +29,8 @@
 
 #include <iostream>
 
-#include <cutil_inline.h>
+#include <helper_cuda.h>
 #include <cuda_runtime.h>
-#include <cutil.h>
 
 #include "Parameters.h"
 
@@ -163,8 +162,8 @@ void TParameters::LoadParametersFromCommandLine(int argc, char **argv){
  */
 void TParameters::StoreParamsOnGPU(){
             
-    cutilSafeCall( 
         cudaMemcpyToSymbol("GPU_EvolutionParameters", &EvolutionParameters, sizeof(TEvolutionParameters) )
+    checkCudaErrors(
     );
     
    

--- a/Parameters.cu
+++ b/Parameters.cu
@@ -162,8 +162,8 @@ void TParameters::LoadParametersFromCommandLine(int argc, char **argv){
  */
 void TParameters::StoreParamsOnGPU(){
             
-        cudaMemcpyToSymbol("GPU_EvolutionParameters", &EvolutionParameters, sizeof(TEvolutionParameters) )
     checkCudaErrors(
+        cudaMemcpyToSymbol(GPU_EvolutionParameters, &EvolutionParameters, sizeof(TEvolutionParameters) )
     );
     
    

--- a/Parameters.h
+++ b/Parameters.h
@@ -68,6 +68,7 @@ struct TEvolutionParameters{
 
 
 
+__constant__  TEvolutionParameters GPU_EvolutionParameters;
 
 
 /*


### PR DESCRIPTION
These changes let you compile the code with CUDA >= 5.0. Although the output seems to be wrong, see #5  for details.

Thanks to:
https://bohipat.wordpress.com/2014/07/11/replacing-cutil-in-cuda-5-0/
http://stackoverflow.com/questions/12947914/error-in-cudamemcpytosymbol-using-cuda-5
